### PR TITLE
move console.log out from curlGenerator function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -116,9 +116,6 @@ export function curlGenerator(options, body = '', regex) {
   result += headers.params + ' ';
   result += generateBody(body) + ' ';
   result += generateCompress(headers.isEncode);
-  console.log(`${chalk.black.bgYellow.bold(' http-to-curl ')}
-  ${result}
-  `);
   return result;
 }
 
@@ -150,7 +147,11 @@ export function requestPatch(regex, request, options, cb, customCallback) {
       body = Buffer.concat(bodyData).toString();
     }
 
-    customCallback(curlGenerator(options, body, regex));
+    const command = curlGenerator(options, body, regex);
+    console.log(`${chalk.black.bgYellow.bold(' http-to-curl ')}
+    ${command}
+    `);
+    customCallback(command);
     return original(data, encoding, cb);
   });
   return clientReq;


### PR DESCRIPTION
This is so we can use `curlGenerator` function without monkeypatching `console.log`