### PR TITLE
add support for search (query string parameters)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
     "http",
     "request-http",
     "debug"
-  ]
+  ],
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -59,8 +59,8 @@ export function generateHeader(options) {
  */
 export function generateUrl(options = {}) {
   if (!options) return '';
-  const { protocol = 'http:', hostname = 'localhost', pathname = '/' } = options;
-  return `"${protocol}//${hostname}${pathname}"`;
+  const { protocol = 'http:', hostname = 'localhost', pathname = '/', search = '' } = options;
+  return `"${protocol}//${hostname}${pathname}${search}"`;
 }
 
 /**

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -113,6 +113,15 @@ describe('Generate URL param', () => {
     };
     expect(generateUrl(options)).toEqual(`\"https://www.google.com/lala\"`);
   });
+  test('Search (query string param)', () => {
+    const options = {
+      protocol: 'https:',
+      hostname: 'www.google.com',
+      pathname: '/lala',
+      search: '?test=123'
+    };
+    expect(generateUrl(options)).toEqual(`\"https://www.google.com/lala?test=123\"`);
+  });
 });
 
 describe('Generate body param', () => {


### PR DESCRIPTION
Before:

```
 http-to-curl 
    curl "https://example.com/path/example" -X GET -H "Accept: application/json, text/plain, */*" -H "User-Agent: axios/1.1.2" -H "Accept-Encoding: gzip, deflate, br"  --compressed
```

After:

```
 http-to-curl 
    curl "https://example.com/path/example?uuid=something" -X GET -H "Accept: application/json, text/plain, */*" -H "User-Agent: axios/1.1.2" -H "Accept-Encoding: gzip, deflate, br"  --compressed

```

Tests are passing (including new one):

```
$ npm run test

> http-to-curl@1.4.3 test http-to-curl
> jest

 PASS  test/main.test.js
  Generate method param
    ✓ No method (1ms)
    ✓ POST
    ✓ PUT
    ✓ GET
    ✓ PATCH
    ✓ DELETE
    ✓ Unknown method (1ms)
  Generate header param
    ✓ No Header Option
    ✓ Has Header
    ✓ Has Encoded Header
  Generate URL param
    ✓ no options
    ✓ Default protocol (1ms)
    ✓ Default hostname
    ✓ Empty Object
    ✓ Default Options
    ✓ Search (query string param)
  Generate body param
    ✓ No Body
    ✓ String Body
    ✓ Object Body
  Generate Compress param
    ✓ No compression
    ✓ Have compression
  Curl generator
    ✓ Basic request
    ✓ single regex request
    ✓ array regex request
    ✓ wrong regex
    ✓ wrong multi regex (1ms)

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        0.987s, estimated 3s
Ran all test suites.
```

Also tested without qsp:

```
 http-to-curl 
    curl "https://example.com/path/example" -X POST -H "Accept: application/json, text/plain, */*" -H "Content-Type: application/json" -H "User-Agent: axios/1.1.2" -H "Accept-Encoding: gzip, deflate, br" --data-binary "{\"myTest\": 1}" --compressed
```